### PR TITLE
Update bundle-audit prior to run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:2.7.0-alpine
 COPY LICENSE README.md /
 COPY entrypoint.sh /entrypoint.sh
 
+RUN apk add git
 RUN gem install bundler bundler-audit
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-bundle-audit check --update
+bundle-audit update
+bundle-audit check


### PR DESCRIPTION
# Bug Fix

## Description

There are two fixes here:

1. Explicitly call `bundle audit update`, defined in the documentation (as opposed to `bundle audit check --update`, previously used)
2. Install git, so that `bundle audit update` can run

Further information:

Hidden in https://github.com/rubysec/bundler-audit/blob/master/lib/bundler/audit/database.rb#L101-L119 bundler-audit is shelling out to use git binary. If it doesn't exist then we get the error message "Skipping update" logged from bundle-audit update.
Install git inside the docker image so bundler audit can grab the latest advisory database for us.
Fixes # (issue)

## Why should this be added

I couldn't make this action run as it always failed on an outdated rails-html-sanitizer vulnerability, that was removed when I ran `bundle audit update`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
