### PR TITLE
Upgrade Ruby version to 3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.0-alpine
+FROM ruby:3.2.2-alpine
 
 COPY LICENSE README.md /
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# Bug fix

## Description
Currently, the action is breaking.

```
 27.58 ERROR:  Error installing bundler:
  27.58 	The last version of bundler (>= 0) to support your
 Ruby & RubyGems was 2.4.22. Try installing it with `gem install
bundler -v 2.4.22`
  27.58 	bundler requires Ruby version >= 3.0.0. The current
ruby version is 2.7.0.0.
```

To fix this, we need to upgrade the version of Ruby.

